### PR TITLE
ENG-386 Add ability to target different organization names

### DIFF
--- a/deployment_pipeline/variables.tf
+++ b/deployment_pipeline/variables.tf
@@ -87,6 +87,12 @@ variable "enable_test_stage" {
   default = false
 }
 
+variable "target_gitops_organization_name" {
+  type = string
+  description = "Gitops organization hosting the target gitops repository. If not provided, defaults to github_organization_name"
+  default = ""
+}
+
 variable "target_gitops_repository" {
   type = string
   description = "Target gitops repository where the image tag update will be pushed (assumes existence of directory kustomization/kustomization.yaml"

--- a/main.tf
+++ b/main.tf
@@ -31,13 +31,14 @@ module "deployment_pipeline" {
   environment_variables            = var.pipelines[each.key].environment_variables
   secret_arns = var.pipelines[each.key].secret_arns
 
-  github_repository_name           = var.github_repository_name
-  github_user = var.github_user
-  github_organization_name         = var.github_repository_organization
-  github_repository_branch         = var.github_repository_branch
-  github_access_token              = var.github_access_token
+  github_repository_name          = var.github_repository_name
+  github_user                     = var.github_user
+  github_organization_name        = var.github_repository_organization
+  github_repository_branch        = var.github_repository_branch
+  github_access_token             = var.github_access_token
   github_access_token_secret_name = var.github_access_token_secret_name
-  target_gitops_repository = var.target_gitops_repository
+  target_gitops_repository        = var.target_gitops_repository
+  target_gitops_organization_name = var.target_gitops_organization_name
 
   devops_slack_webhook             = var.devops_slack_webhook
   devops_slack_channel_name        = var.devops_slack_channel_name

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,12 @@ variable "cloudwatch_log_retention_in_days" {
   description = "CloudWatch log retention for /aws/lambda/* and cosmos-*-webhook-proxy-api-gateway"
 }
 
+variable "target_gitops_organization_name" {
+  type = string
+  description = "Gitops organization hosting the target gitops repository. If not provided, defaults to github_organization_name"
+  default = ""
+}
+
 variable "target_gitops_repository" {
   type = string
   description = "Target gitops repository where the image tag update will be pushed (assumes existence of directory kustomization/kustomization.yaml"


### PR DESCRIPTION
Add ability for repo and gitops repo to be hosted in different organizations. This should allow for quite a few use cases, including having a client own a repository but Airnauts owning the gitops repositories